### PR TITLE
Update exception message in elasticsearch

### DIFF
--- a/src/Services/Elasticsearch.php
+++ b/src/Services/Elasticsearch.php
@@ -109,7 +109,7 @@ class Elasticsearch
             return $this->client->update($params);
         } catch (Exception $e) {
             $response = json_decode($e->getMessage(), true);
-            throw new ExceptionsException($response['error']['caused_by']['reason']);
+            throw new ExceptionsException($response['error']);
         }
     }
 }


### PR DESCRIPTION
get only the error object since some error on es does not container 'caused_by' key'